### PR TITLE
Add MCP Client Integration Instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,102 @@ cd story-sdk-mcp
 uv run mcp dev server.py
 ```
 
+## Using with MCP Clients
+
+Follow the instructions below to connect the MCP servers to various MCP-compatible clients.
+
+### Cursor
+
+Cursor implements an MCP client that supports an arbitrary number of MCP servers with both `stdio` and `sse` transports.
+
+#### Adding MCP Servers in Cursor
+
+1. Go to `Cursor Settings` > `Features` > `MCP`
+2. Click on the `+ Add New MCP Server` button
+3. Fill out the form:
+   - Select the transport under `Type`
+   - Enter a nickname for the server in the `Name` field
+   - Enter either the command to run or the URL of the server, depending on the transport
+   - We'll use the `uv` command to run the server, so make sure to include the `--directory` flag with the path to the server (Example: `uv --directory ~/path/to/story-mcp-hub/storyscan-mcp run server.py`)
+
+#### Project-Specific MCP Configuration
+
+You can configure project-specific MCP servers using `.cursor/mcp.json`. The file follows this format:
+
+```json
+{
+  "mcpServers": {
+    "storyscan-mcp": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "~/path/to/story-mcp-hub/storyscan-mcp",
+        "run",
+        "server.py"
+      ]
+    },
+    "story-sdk-mcp": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "~/path/to/story-mcp-hub/story-sdk-mcp",
+        "run",
+        "server.py"
+      ]
+    }
+  }
+}
+```
+
+#### Using MCP Tools in Cursor
+
+The Composer Agent will automatically use any MCP tools that are listed under `Available Tools` on the MCP settings page if it determines them to be relevant. To prompt tool usage intentionally, simply tell the agent to use the tool, referring to it either by name or by description.
+
+When the Agent wants to use an MCP tool, it will display a message asking for your approval.
+
+### Claude Desktop
+
+Claude Desktop can be configured to use MCP servers by editing its configuration file.
+
+#### Adding MCP Servers in Claude Desktop
+
+1. Open the Claude Desktop configuration file:
+
+```bash
+code ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+2. Add the MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "storyscan-mcp": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "~/path/to/story-mcp-hub/storyscan-mcp",
+        "run",
+        "server.py"
+      ]
+    },
+    "story-sdk-mcp": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "~/path/to/story-mcp-hub/story-sdk-mcp",
+        "run",
+        "server.py"
+      ]
+    }
+  }
+}
+```
+
+3. Save the file and restart Claude Desktop for the changes to take effect.
+
+Example query: `use storyscan to check balance of 0x95A13F457C76d10A40D7e8497eD4F40c53F4d04b`
+
 ## Development
 
 To add a new MCP server to the hub:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Cursor implements an MCP client that supports an arbitrary number of MCP servers
    - Enter either the command to run or the URL of the server, depending on the transport
    - We'll use the `uv` command to run the server, so make sure to include the `--directory` flag with the path to the server (Example: `uv --directory ~/path/to/story-mcp-hub/storyscan-mcp run server.py`)
 
+![Screenshot 2025-03-10 at 2 50 48 PM](https://github.com/user-attachments/assets/a2f1e624-3f13-4eb7-b16b-b347cea8b339)
+
 #### Project-Specific MCP Configuration
 
 You can configure project-specific MCP servers using `.cursor/mcp.json`. The file follows this format:
@@ -254,6 +256,8 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
 3. Save the file and restart Claude Desktop for the changes to take effect.
+
+![Screenshot 2025-03-10 at 2 57 24 PM](https://github.com/user-attachments/assets/6901e488-09a7-452a-b1cd-17aa525cac2a)
 
 Example query: `use storyscan to check balance of 0x95A13F457C76d10A40D7e8497eD4F40c53F4d04b`
 


### PR DESCRIPTION
## Description
This PR enhances the README with clear instructions for integrating Story MCP Hub servers with Cursor and Claude Desktop clients. The updates provide step-by-step guidance for configuring both clients to use the StoryScan and Story SDK MCP servers.

## Changes
- Added new "Using MCP Servers with Clients" section
- Included detailed Cursor integration instructions with:
  - UI configuration steps
  - Project-specific `.cursor/mcp.json` setup
  - Example usage pattern
- Added Claude Desktop configuration instructions with:
  - Configuration file location and editing process
  - JSON configuration examples
  - Restart requirements

## Testing
Verified configuration examples work with both clients using the correct paths and command structures.
